### PR TITLE
docs(install-guide): fix text capitalization errors

### DIFF
--- a/docs/software-configuration/x86_64-based_ECU/source-installation.md
+++ b/docs/software-configuration/x86_64-based_ECU/source-installation.md
@@ -46,7 +46,7 @@
    Then, import the necessary packages using vcs:
    ```bash
    # Note: Make sure to run the following commands locally on your machine (not over remote SSH)
-   vcs import src < Autoware.repos  
+   vcs import src < autoware.repos  
    ```
    ```bash
    vcs import src < extra-packages.repos


### PR DESCRIPTION
Dear Maintainers,

This pull request fixes a minor typo in the installation guide.
The command:

vcs import src < Autoware.repos

was mistakenly written with a capital "A" in Autoware.repos,
but the correct filename uses a lowercase "a": autoware.repos.

This change updates the documentation accordingly to avoid confusion during setup.

Thank you very much for your review and kind consideration.

Best regards,
Timmy.Hu @ Advantech