### PR TITLE
docs: refer to Nebula

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -24,6 +24,7 @@
     "Venkat",
     "gokart",
     "avev",
-    "webp"
+    "webp",
+    "iotop"
   ]
 }

--- a/docs/software-configuration/sensor-configuration/index.md
+++ b/docs/software-configuration/sensor-configuration/index.md
@@ -71,7 +71,8 @@ For real-time communication requirements, configure TSN on supported hardware:
 
 For a plug-and-play experience with Autoware, the [Nebula](https://github.com/tier4/nebula) project
 provides a common interface for various LiDAR vendors, including Hesai, Velodyne and RoboSense.
-Visit the [Nebula documentation](https://tier4.github.io/nebula/) for more information.
+Nebula currently ships as part of the Autoware stack. Visit the 
+[Nebula documentation](https://tier4.github.io/nebula/) for more information.
 
 Alternatively, many vendors provide ROS 2 drivers for their LiDAR sensors. Vendor-specific
 installation and configuration are documented below.

--- a/docs/software-configuration/sensor-configuration/index.md
+++ b/docs/software-configuration/sensor-configuration/index.md
@@ -69,6 +69,13 @@ For real-time communication requirements, configure TSN on supported hardware:
 
 ## LiDAR Configuration
 
+For a plug-and-play experience with Autoware, the [Nebula](https://github.com/tier4/nebula) project
+provides a common interface for various LiDAR vendors, including Hesai, Velodyne and RoboSense.
+Visit the [Nebula documentation](https://tier4.github.io/nebula/) for more information.
+
+Alternatively, many vendors provide ROS 2 drivers for their LiDAR sensors. Vendor-specific
+installation and configuration are documented below.
+
 ### Velodyne LiDAR
 
 Velodyne LiDARs use UDP packets for data transmission over Ethernet. For hardware specifications and supported models, see [Velodyne Hardware Information](../../hardware-configuration/Sensors-and-Actuators/lidars.md#velodyne-3d-lidar-sensors).


### PR DESCRIPTION
Setting up third-party sensors with Autoware is not always frictionless. 
Especially 
* packet recording and offline replay
* configuration
* point cloud formats
are common pain points.

This PR adds a reference to TIER IV's Nebula project, which is [officially ships with](https://github.com/autowarefoundation/autoware/blob/ab8c29f05a2584dd856e57c1967340b51965b059/repositories/autoware.repos#L103) Autoware.